### PR TITLE
Corrección de appDir utilizado.

### DIFF
--- a/data/db/sequelize/index.js
+++ b/data/db/sequelize/index.js
@@ -1,8 +1,11 @@
 const fs = require('fs');
 const path = require('path');
-var appDir = path.dirname(require.main.filename);
 const Sequelize = require('sequelize');
-const nconf = require.main.require(appDir + '/config');
+
+const utils = require('../../../utils');
+
+const { appDir } = utils.pathUtils;
+const nconf = require.main.require(`${appDir}/config`);
 
 const username = nconf.get('database:user');
 const password = nconf.get('database:password');
@@ -14,16 +17,14 @@ const models = {};
 
 
 fs
-  .readdirSync(appDir + '/data/models')
-  .filter(function (file) {
-    return (file.indexOf('.') !== 0) && (file !== 'index.js');
-  })
-  .forEach(function (file) {
-    var model = client.import(path.join(appDir + '/data/models', file));
+  .readdirSync(`${appDir}/data/models`)
+  .filter(file => (file.indexOf('.') !== 0) && (file !== 'index.js'))
+  .forEach((file) => {
+    const model = client.import(path.join(`${appDir}/data/models`, file));
     models[model.name] = model;
   });
 
-Object.keys(models).forEach(function (modelName) {
+Object.keys(models).forEach((modelName) => {
   if (models[modelName].hasOwnProperty('associate')) {
     models[modelName].associate(models);
   }

--- a/middleware/authenticated.js
+++ b/middleware/authenticated.js
@@ -13,11 +13,10 @@
  * @since 0.1.0
  */
 const jwt = require('koa-jwt');
-const path = require('path');
-var appDir = path.dirname(require.main.filename);
+const utils = require('../utils');
 
-const nconf = require.main.require(appDir + '/config');
-
+const { appDir } = utils.pathUtils;
+const nconf = require.main.require(`${appDir}/config`);
 
 module.exports = jwt({
   secret: nconf.get('jwt:secret'),

--- a/middleware/authorize.js
+++ b/middleware/authorize.js
@@ -2,9 +2,6 @@ const Boom = require('boom');
 const jwt = require('jsonwebtoken');
 const path = require('path');
 
-var appDir = path.dirname(require.main.filename);
-const nconf = require.main.require(appDir + '/config');
-
 const authorizationMiddleware = userPermFinder => requiredParams => {
   return async (ctx, next) => {
     console.log('Se solicitan los permisos', requiredParams);

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,0 +1,1 @@
+exports.pathUtils = require('./pathUtils');

--- a/utils/pathUtils.js
+++ b/utils/pathUtils.js
@@ -9,8 +9,9 @@ const path = require('path');
  */
 function getAppDir() {
   // Se controla si el módulo está siendo utilizado como dependencia.
-  if(__dirname.includes('/node_modules/node-toolkit/')){
-    return __dirname.split('/node_modules/node-toolkit/')[0];
+  const pattern = `${path.sep}node_modules${path.sep}node-toolkit${path.sep}`;
+  if(__dirname.includes(pattern)){
+    return __dirname.split(pattern)[0];
   }
   return path.dirname(require.main.filename);
 }

--- a/utils/pathUtils.js
+++ b/utils/pathUtils.js
@@ -1,0 +1,18 @@
+const path = require('path');
+
+/**
+ * Obtiene el path a la aplicación que está usando a node-toolkit como
+ * dependencia. Si no se está usando el módulo como dependencia se retorna
+ * require.main.filename (esto ultimo podría ser incompatible con aplicaciones 
+ * ejecutadas desde iisnode en Windows/Azure ya que require.main.filename
+ * retornaria un path similar a D:\Program Files (x86)\iisnode).
+ */
+function getAppDir() {
+  // Se controla si el módulo está siendo utilizado como dependencia.
+  if(__dirname.includes('/node_modules/node-toolkit/')){
+    return __dirname.split('/node_modules/node-toolkit/')[0];
+  }
+  return path.dirname(require.main.filename);
+}
+
+exports.appDir = getAppDir();


### PR DESCRIPTION
Actualmente se está utilizando `require.main.filename` para obtener el punto de entrada a la aplicación. Esto podría ser incompatible con aplicaciones ejecutadas en `iisnode` (Windows/Azure) ya que `require.main.filename` retornaría un path similar a `D:\Program Files (x86)\iisnode`, (ver https://stackoverflow.com/a/20482383).

En este PR se aplican los siguientes cambios: 

- Se agrega la función `getAppDir()` para obtener el punto de entrada a la aplicación (ver  utils/pathUtils.js), considerando que se está utilizando este módulo como dependencia.
- Se reemplazan todas las ocurrencias de `require.main.filename` por el valor devuelto por `getAppDir()`.