### PR TITLE
Corrección de parseFilter cuando la condición es $eq.

### DIFF
--- a/middleware/persistence-data-parser.js
+++ b/middleware/persistence-data-parser.js
@@ -48,7 +48,7 @@ const parseFilter = (key, value) => {
     const filter = {};
     const filterObject = {};
     var filterParsedObject = parseFilterMethod(key);
-    if(filterParsedObject.hasOwnProperty("condition")) {
+    if(filterParsedObject.hasOwnProperty("condition") && filterParsedObject["condition"] !== '$eq') {
         filterObject[filterParsedObject["condition"]] = '%' + value + '%';
     } else {
         //Si no hay una condicion especifica, usamos eq como default

--- a/middleware/persistence-data-parser.js
+++ b/middleware/persistence-data-parser.js
@@ -48,8 +48,8 @@ const parseFilter = (key, value) => {
     const filter = {};
     const filterObject = {};
     var filterParsedObject = parseFilterMethod(key);
-    if(filterParsedObject.hasOwnProperty("condition") && filterParsedObject["condition"] !== '$eq') {
-        filterObject[filterParsedObject["condition"]] = '%' + value + '%';
+    if(filterParsedObject.hasOwnProperty("condition")) {
+        filterObject[filterParsedObject["condition"]] = filterParsedObject["condition"] === '$like' ? `%${value}%` : value;
     } else {
         //Si no hay una condicion especifica, usamos eq como default
         filterObject['$eq'] = value;


### PR DESCRIPTION
Se corrige el parseo de filtros que usan $eq como
condición debido a que actualmente se está concatenando
'%' al valor y esto hace que la condición nunca pueda cumplirse.